### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "urls": [
+    ["lidarLitev3hp.py", "github:Dnapert/LidarLight_v3HP_micropython/lidarLitev3hp.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
Add `package.json` file for compatibility with the MicroPython package manager (MIP). 

With this change, users can install the module using: `mpremote mip install github:Dnapert/LidarLight_v3HP_micropython`